### PR TITLE
NO-TASK - Reorganizing collection links functionality.

### DIFF
--- a/easyopac_collection_links.module
+++ b/easyopac_collection_links.module
@@ -22,12 +22,31 @@ function easyopac_collection_links_menu() {
   $items['previews'] = [
     'title' => 'Get previews for ting objects',
     'page callback' => 'easyopac_collection_links_ajax_callback',
-    'page arguments' => [1],
+    'access arguments' => ['access content'],
+    'type' => MENU_CALLBACK,
+  ];
+
+  $items['ecl-proxy'] = [
+    'title' => 'Proxy request to Ereolen',
+    'page callback' => 'easyopac_collection_links_proxy',
     'access arguments' => ['access content'],
     'type' => MENU_CALLBACK,
   ];
 
   return $items;
+}
+
+/**
+ * Proxying requests to eReolen.
+ */
+function easyopac_collection_links_proxy() {
+  $qp = drupal_get_query_parameters();
+
+  if (isset($qp['url'])) {
+    drupal_add_http_header('Access-Control-Allow-Origin', '*');
+
+    echo file_get_contents($qp['url']);
+  }
 }
 
 /**
@@ -37,6 +56,12 @@ function easyopac_collection_links_page_alter(&$vars) {
   $args = arg();
 
   if ($args[0] == 'search' && $args[1] == 'ting' || $args[0] == 'ting' && ($args[1] == 'object' || $args[1] == 'collection')) {
+    drupal_add_js(
+      [
+        'easyopac_collection_links' => [
+          'page_type' => $args[1],
+        ],
+      ], 'setting');
     drupal_add_js(drupal_get_path('module', 'easyopac_collection_links') . '/js/easyopac_collection_links.js', [
       'type' => 'file',
       'scope' => 'footer',
@@ -52,7 +77,8 @@ function easyopac_collection_links_ajax_callback() {
   $result = [];
   if (!empty($_POST['previewedIds']) && is_array($_POST['previewedIds'])) {
     $ids = $_POST['previewedIds'];
-    $result = easyopac_collection_links_make_request($ids);
+    $page_type = $_POST['pageType'];
+    $result = easyopac_collection_links_make_request($ids, $page_type);
   }
 
   drupal_json_output($result);
@@ -63,10 +89,12 @@ function easyopac_collection_links_ajax_callback() {
  * Perform request to LMS.
  *
  * @param array $ids
+ * @param string $type
  *
  * @return array|void
  */
-function easyopac_collection_links_make_request(array $ids) {
+function easyopac_collection_links_make_request(array $ids, $type) {
+  $items = [];
   $lms_service_url = variable_get('easyopac_collection_links_lms_service_url', NULL);
 
   if (empty($lms_service_url)) {
@@ -77,23 +105,49 @@ function easyopac_collection_links_make_request(array $ids) {
     return;
   }
 
-  $ids = implode(',', $ids);
+  if ($type == 'collection' || $type == 'object') {
+    $action = '/detail';
 
-  $items = [];
-  $options = [
-    'include' => $ids,
-    'withMeta' => NULL,
-  ];
-  $url = url($lms_service_url . '/search', ['query' => $options]);
+    if ($type == 'object') {
+      $ids[] = array_shift($ids);
+    }
+
+    $id = $ids[0];
+
+    $options = [
+      'faustNumber' => $id,
+      'withExternalResources' => NULL,
+      'withNoCover' => NULL,
+    ];
+  }
+  else {
+    $action = '/search';
+    $ids = implode(',', $ids);
+
+    $options = [
+      'include' => $ids,
+      'withMeta' => NULL,
+    ];
+  }
+  $url = url($lms_service_url . $action, ['query' => $options]);
 
   $response = drupal_http_request($url);
   if ($response->code == '200') {
     $data = drupal_json_decode($response->data);
-    $data = $data['objects'];
 
-    foreach ($data as $datum) {
-      if (!empty($datum['externalResources'])) {
-        $items[$datum['id']] = easyopac_collection_links_generate_preview_url($datum['externalResources']);
+    if ($type == 'ting') {
+      $data = $data['objects'];
+      foreach ($data as $datum) {
+        if (!empty($datum['externalResources'])) {
+          $items[$datum['id']] = easyopac_collection_links_generate_preview_url($datum['externalResources']);
+        }
+      }
+    }
+    else {
+      if (!empty($data['externalResources'])) {
+        foreach ($ids as $id) {
+          $items[$id] = easyopac_collection_links_generate_preview_url($data['externalResources']);
+        }
       }
     }
   }
@@ -119,6 +173,7 @@ function easyopac_collection_links_ding_entity_buttons($type, $entity) {
       ],
       'target' => '_blank',
       'data-preview-id' => $entity->id,
+      'data-preview-type' => $type,
     ],
     '#weight' => 100,
   ];
@@ -173,6 +228,30 @@ function easyopac_collection_links_preprocess_ting_object(&$variables) {
       ];
 
       $variables['content']['ting_primary_object'][0]['previews_button'] = $collection_button;
+    }
+  }
+  else if (!$multiple && ($view_mode == 'full' || $view_mode == 'collection_list')) {
+    $entity_buttons = $variables['elements']['ding_entity_buttons'][0];
+
+    foreach ($entity_buttons as $key => $entity_button) {
+      if ($entity_button['#title'] == 'Preview') {
+        unset($variables['elements']['ding_entity_buttons'][0][$key]);
+      }
+    }
+
+    $button_types = ['audiobook', 'ebook'];
+
+    foreach ($button_types as $button_type) {
+      $button = easyopac_collection_links_ding_entity_buttons($button_type, $variables['elements']['#object']);
+      $variables['elements']['ding_entity_buttons'][0][] = reset($button);
+    }
+  }
+  else if ($view_mode == 'teaser') {
+    $button_types = ['audiobook', 'ebook'];
+
+    foreach ($button_types as $button_type) {
+      $button = easyopac_collection_links_ding_entity_buttons($button_type, $variables['elements']['#object']);
+      $variables["elements"]["ting_primary_object"][0]["ding_entity_buttons"][0][] = reset($button);
     }
   }
 }

--- a/js/easyopac_collection_links.js
+++ b/js/easyopac_collection_links.js
@@ -8,7 +8,12 @@
 
   $(document).ready(function () {
     let previewedIds = [];
+    let mobile = false;
     let selector = '.button-preview';
+
+    if ($('body').hasClass('has-touch')) {
+      mobile = true;
+    }
 
     $(selector).each(function () {
       previewedIds.push($(this).data("preview-id"));
@@ -20,25 +25,51 @@
         type: 'POST',
         url: '/previews',
         data: {
-          previewedIds: previewedIds
+          previewedIds: previewedIds,
+          pageType: Drupal.settings.easyopac_collection_links.page_type,
         },
         success: function (result) {
           $.each(result, function (previewedId, previewLinks) {
             $.each(previewLinks, function (previewType, previewLink) {
               if (previewLink) {
+                let cbHeight = '95%';
                 let btnTitle = Drupal.t('Preview');
+                let inlineStyle = {
+                  overflow: 'overflow: hidden;',
+                  width: "width: 100%;"
+                };
+
                 if (previewType === 'ebook') {
                   btnTitle = Drupal.t('Preview ebook');
+                  inlineStyle.height = "height: 95%;";
                 }
                 if (previewType === 'audiobook') {
                   btnTitle = Drupal.t('Preview audiobook');
+                  inlineStyle.height = "height: 400px;";
+                  cbHeight = '350px';
                 }
 
-                $(selector + '[data-preview-id="' + previewedId + '"]')
+                let styles = Object.keys(inlineStyle).map(function (key) {
+                  return inlineStyle[key];
+                }).join(' ');
+
+                let btn = $(selector + '[data-preview-id="' + previewedId + '"][data-preview-type="' + previewType + '"]')
                   .attr('href', previewLink)
                   .removeClass('previewable-pending')
                   .addClass('previewable')
                   .html(btnTitle);
+
+                if (mobile === false) {
+                  btn.colorbox({
+                    height: cbHeight,
+                    width: '1140px',
+                    scrolling: false,
+                    html: "<iframe src='/ecl-proxy?url=" + previewLink + "' style='" + styles + "'></iframe>",
+                  });
+                }
+                else {
+                  btn.attr('target', '_blank');
+                }
 
                 // Add some styling for collection items.
                 $('.collections-preview--collection-wrapper').find('.previewable').parent().css('border-top', '1px solid #c6c6c6');


### PR DESCRIPTION
- For `search result` view will be made request to `/search` endpoint, while for `collection` and `full` views an request to `/detail` will be done.
- Each item on `collection` page will own all buttons available.
- Added an endpoint for proxying requests to `/read and /listen` urls on ereolen, because direct access from iframe is not allowed by requested server.
- In `desktop` mode, previews will be opened in colorbox modal window, on mobile devices it will be opened in new tab.